### PR TITLE
Truncate time to milliseconds

### DIFF
--- a/core/src/main/kotlin/com/codattle/core/dao/common/DaoUtils.kt
+++ b/core/src/main/kotlin/com/codattle/core/dao/common/DaoUtils.kt
@@ -13,6 +13,7 @@ import org.litote.kmongo.projection
 import org.litote.kmongo.util.KMongoUtil
 import java.lang.IllegalArgumentException
 import java.time.Instant
+import java.time.temporal.ChronoUnit
 import javax.inject.Singleton
 import kotlin.reflect.KProperty
 
@@ -119,7 +120,8 @@ class DaoUtils(
 
     private fun fillAuditFields(entity: DaoModelBuilder<*>) {
         if (entity.creationDate == null) {
-            entity.creationDate = Instant.now()
+            // The date type in MongoDB has only millisecond resolution
+            entity.creationDate = Instant.now().truncatedTo(ChronoUnit.MILLIS)
         }
     }
 }


### PR DESCRIPTION
Unit tests didn't work on Java 9+ (Travis uses Java 11) because `Instant.now()` in Java 9+ has microsecond resolution and MongoDB only millisecond resolution. So expression `gameService.getGame(game.id).creationDate == game.creationDate` wasn't true.